### PR TITLE
Change uart baud rate to 115200

### DIFF
--- a/board/pine64/ox64/patches/linux/0022-Change-serial-baud-to-115200.patch
+++ b/board/pine64/ox64/patches/linux/0022-Change-serial-baud-to-115200.patch
@@ -1,0 +1,41 @@
+From 1724d399250475f697532e0e790e7314783f470a Mon Sep 17 00:00:00 2001
+From: "Grant T. Olson" <kgo@grant-olson.net>
+Date: Fri, 27 Jan 2023 12:07:47 -0500
+Subject: [PATCH] Change serial baud rate with CP2102 UART boards.
+
+---
+ arch/riscv/boot/dts/bouffalolab/bl808-pine64-ox64.dts | 4 ++--
+ drivers/tty/serial/bflb_uart.c                        | 2 +-
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/arch/riscv/boot/dts/bouffalolab/bl808-pine64-ox64.dts b/arch/riscv/boot/dts/bouffalolab/bl808-pine64-ox64.dts
+index ce80095940de..03ee80d87620 100644
+--- a/arch/riscv/boot/dts/bouffalolab/bl808-pine64-ox64.dts
++++ b/arch/riscv/boot/dts/bouffalolab/bl808-pine64-ox64.dts
+@@ -17,8 +17,8 @@ aliases {
+ 	};
+ 
+ 	chosen {
+-		stdout-path = "serial0:2000000n8";
+-		bootargs = "console=ttyS0,2000000 loglevel=8 earlycon=sbi root=PARTLABEL=rootfs rootwait rootfstype=ext4";
++		stdout-path = "serial0:115200n8";
++		bootargs = "console=ttyS0,115200 loglevel=8 earlycon=sbi root=PARTLABEL=rootfs rootwait rootfstype=ext4";
+ 		linux,initrd-start = <0x0 0x52000000>;
+ 		linux,initrd-end = <0x0 0x52941784>;
+ 	};
+diff --git a/drivers/tty/serial/bflb_uart.c b/drivers/tty/serial/bflb_uart.c
+index 5911f489959c..87a73c77f90a 100644
+--- a/drivers/tty/serial/bflb_uart.c
++++ b/drivers/tty/serial/bflb_uart.c
+@@ -80,7 +80,7 @@
+ #define  UART_FIFO_RDATA_MSK		GENMASK(7, 0)
+ 
+ #define BFLB_UART_MAXPORTS 		8
+-#define BFLB_UART_BAUD			2000000
++#define BFLB_UART_BAUD			115200
+ #define BFLB_UART_RX_FIFO_TH		7
+ #define BFLB_UART_TX_FIFO_DEPTH		32
+ 
+-- 
+2.34.1
+

--- a/board/pine64/ox64/patches/oblfr/0001-Change-baud-rate-to-115200-to-be-compatible-with-CP2.patch
+++ b/board/pine64/ox64/patches/oblfr/0001-Change-baud-rate-to-115200-to-be-compatible-with-CP2.patch
@@ -1,0 +1,39 @@
+From e29daa016948d06a777b45cc93e6d86604b24f3a Mon Sep 17 00:00:00 2001
+From: "Grant T. Olson" <kgo@grant-olson.net>
+Date: Sun, 29 Jan 2023 13:15:16 -0500
+Subject: [PATCH] Change baud rate to 115200 to be compatible with CP2102
+
+---
+ apps/d0_lowload/src/main.c | 2 +-
+ bsp/ox64/board.c           | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/apps/d0_lowload/src/main.c b/apps/d0_lowload/src/main.c
+index 140c149..fef1b9e 100644
+--- a/apps/d0_lowload/src/main.c
++++ b/apps/d0_lowload/src/main.c
+@@ -202,7 +202,7 @@ int main(void)
+     bflb_gpio_init(gpio, GPIO_PIN_17, 21 | GPIO_ALTERNATE | GPIO_PULLUP | GPIO_SMT_EN | GPIO_DRV_1);
+ 
+     struct bflb_uart_config_s cfg;
+-    cfg.baudrate = 2000000;
++    cfg.baudrate = 115200;
+     cfg.data_bits = UART_DATA_BITS_8;
+     cfg.stop_bits = UART_STOP_BITS_1;
+     cfg.parity = UART_PARITY_NONE;
+diff --git a/bsp/ox64/board.c b/bsp/ox64/board.c
+index 846b9f1..ca1b10f 100644
+--- a/bsp/ox64/board.c
++++ b/bsp/ox64/board.c
+@@ -204,7 +204,7 @@ static void console_init()
+     bflb_gpio_init(gpio, GPIO_PIN_17, 21 | GPIO_ALTERNATE | GPIO_PULLUP | GPIO_SMT_EN | GPIO_DRV_1);
+ #endif
+     struct bflb_uart_config_s cfg;
+-    cfg.baudrate = 2000000;
++    cfg.baudrate = 115200;
+     cfg.data_bits = UART_DATA_BITS_8;
+     cfg.stop_bits = UART_STOP_BITS_1;
+     cfg.parity = UART_PARITY_NONE;
+-- 
+2.34.1
+


### PR DESCRIPTION
It is a well-known problem that the initial programming of the Ox64 is a bit tricky, and many USB-to-UART adapters don't work. Even though I had existing adapters, I still needed to purchase two different chipsets until I could find one that worked.

The CP2102 works, but only at 115200 baud. With the current baud rate of 2000000 I need to switch chips after programming to see the output.

This patch changes the baud rates to a much more standard 115200 baud, which is likely to work with all UART adapters out there.

I think at this point it is best to make it as easy as possible to developers to get their boards up and running, and think this patch removes one obstacle that is making development frustrating.