### PR TITLE
try to fix SD card problems by adding SDH clock overrides to U-Boot and the kernel

### DIFF
--- a/board/pine64/ox64/patches/linux/0032-override-SD-bus-clock-divider-BL808.patch
+++ b/board/pine64/ox64/patches/linux/0032-override-SD-bus-clock-divider-BL808.patch
@@ -1,0 +1,65 @@
+From: Werner Almesberger <werner@almesberger.net>
+Subject: override for SD bus clock divider on BL808
+
+--- a/drivers/mmc/host/sdhci-bflb.c.orig	2023-04-18 10:22:35.775866090 -0300
++++ b/drivers/mmc/host/sdhci-bflb.c	2023-04-18 12:40:42.326450247 -0300
+@@ -5,9 +5,13 @@
+ #include <linux/io.h>
+ #include <linux/mmc/host.h>
+ #include <linux/module.h>
++#include <linux/moduleparam.h>
+ #include <linux/of.h>
+ 
+ #include "sdhci-pltfm.h"
++#include "sdhci.h"
++
++static unsigned bus_div_override = 0;
+ 
+ static u16 sdhci_bflb_readw(struct sdhci_host *host, int reg)
+ {
+@@ -39,6 +43,28 @@
+ 	return ret;
+ }
+ 
++static void sdhci_bflb_set_ios(struct mmc_host *mmc, struct mmc_ios *ios)
++{
++	struct sdhci_host *host = mmc_priv(mmc);
++	unsigned old, new;
++
++	sdhci_set_ios(mmc, ios);
++
++	if (bus_div_override) {
++		old = new = sdhci_readw(host, SDHCI_CLOCK_CONTROL);
++		new &= ~(SDHCI_DIV_MASK << SDHCI_DIVIDER_SHIFT |
++		    (SDHCI_DIV_HI_MASK >> SDHCI_DIV_MASK_LEN)
++		    << SDHCI_DIVIDER_HI_SHIFT);
++		    new |= ((bus_div_override - 1) & SDHCI_DIV_MASK)
++		    << SDHCI_DIVIDER_SHIFT;
++		new |= (((bus_div_override - 1) & SDHCI_DIV_HI_MASK) >>
++		    SDHCI_DIV_MASK_LEN) << SDHCI_DIVIDER_HI_SHIFT;
++		dev_info(mmc_dev(mmc),
++		    "SDHCI_CLOCK_CONTROL: 0x%04x -> 0x%04x\n", old, new);
++		sdhci_writew(host, new, SDHCI_CLOCK_CONTROL);
++	}
++}
++
+ static const struct sdhci_ops sdhci_bflb_ops = {
+ 	.read_w	= sdhci_bflb_readw,
+ 	.read_l	= sdhci_bflb_readl,
+@@ -74,6 +100,8 @@
+ 	if (!IS_ERR(pltfm_host->clk))
+ 		clk_prepare_enable(pltfm_host->clk);
+ 
++	host->mmc_host_ops.set_ios = sdhci_bflb_set_ios;
++
+ 	ret = mmc_of_parse(host->mmc);
+ 	if (ret)
+ 		goto err_sdhci_add;
+@@ -108,6 +136,7 @@
+ };
+ 
+ module_platform_driver(sdhci_bflb_driver);
++module_param_hw_named(bus_div, bus_div_override, uint, other, 0444);
+ 
+ MODULE_DESCRIPTION("SDHCI driver for Bflb");
+ MODULE_LICENSE("GPL v2");

--- a/board/pine64/ox64/patches/uboot/0003-override-SDH-clock-dividers-BL808.patch
+++ b/board/pine64/ox64/patches/uboot/0003-override-SDH-clock-dividers-BL808.patch
@@ -1,0 +1,99 @@
+From: Werner Almesberger <werner@almesberger.net>
+Subject: override for SDH clock dividers on BL808
+
+--- a/drivers/mmc/bflb_sdhci.c.orig	2023-04-17 21:42:50.549404368 -0300
++++ b/drivers/mmc/bflb_sdhci.c	2023-04-17 22:06:52.379389437 -0300
+@@ -1,5 +1,8 @@
+ // SPDX-License-Identifier: GPL-2.0+
+ 
++#include <common.h>
++#include <command.h>
++#include <bl808/glb_reg.h>
+ #include <clk.h>
+ #include <dm.h>
+ #include <mmc.h>
+@@ -10,6 +13,9 @@
+ 	struct mmc		mmc;
+ };
+ 
++static unsigned sdh_override = 0;
++static unsigned bus_override = 0;
++
+ static int bflb_sdhci_bind(struct udevice *dev)
+ {
+ 	struct bflb_sdhci_plat *plat = dev_get_plat(dev);
+@@ -17,6 +23,38 @@
+ 	return sdhci_bind(dev, &plat->mmc, &plat->cfg);
+ }
+ 
++static int bflb_sdhci_set_ios_post(struct sdhci_host *host)
++{
++	unsigned old, new;
++
++	if (sdh_override) {
++		old = new =
++		    *(volatile uint32_t *) (GLB_SDH_CFG0_OFFSET | 0x20000000);
++		new &= ~GLB_REG_SDH_CLK_DIV_MSK;
++		new |= ((sdh_override - 1) << GLB_REG_SDH_CLK_DIV_POS) &
++		    GLB_REG_SDH_CLK_DIV_MSK;
++		printf("SDH_CFG0: 0x%08x -> 0x%08x\n", old, new);
++		*(volatile uint32_t *) (GLB_SDH_CFG0_OFFSET | 0x20000000) = new;
++	}
++	if (bus_override) {
++		old = new = sdhci_readw(host, SDHCI_CLOCK_CONTROL);
++		new &= ~(SDHCI_DIV_MASK << SDHCI_DIVIDER_SHIFT |
++		    (SDHCI_DIV_HI_MASK >> SDHCI_DIV_MASK_LEN)
++		    << SDHCI_DIVIDER_HI_SHIFT);
++		new |= ((bus_override - 1) & SDHCI_DIV_MASK)
++		    << SDHCI_DIVIDER_SHIFT;
++		new |= (((bus_override - 1) & SDHCI_DIV_HI_MASK) >>
++		    SDHCI_DIV_MASK_LEN) << SDHCI_DIVIDER_HI_SHIFT;
++		printf("SDHCI_CLOCK_CONTROL: 0x%04x -> 0x%04x\n", old, new);
++		sdhci_writew(host, new, SDHCI_CLOCK_CONTROL);
++	}
++	return 0;
++}
++
++static const struct sdhci_ops bflb_sdhci_ops = {
++	.set_ios_post = bflb_sdhci_set_ios_post
++};
++
+ static int bflb_sdhci_probe(struct udevice *dev)
+ {
+ 	struct mmc_uclass_priv *upriv = dev_get_uclass_priv(dev);
+@@ -47,6 +85,7 @@
+ 	host->mmc = &plat->mmc;
+ 	host->mmc->dev = dev;
+ 	host->mmc->priv = host;
++	host->ops = &bflb_sdhci_ops;
+ 	upriv->mmc = &plat->mmc;
+ 
+ 	ret = sdhci_setup_cfg(&plat->cfg, host, 0, 0);
+@@ -65,6 +104,27 @@
+ 	return ret;
+ }
+ 
++static int do_bflb_sdhci(struct cmd_tbl *cmdtp, int flag, int argc,
++    char *const argv[])
++{
++	if (argc != 3)
++		return CMD_RET_USAGE;
++
++        if (!strncmp(argv[1], "sdh", 3))
++                sdh_override = simple_strtoul(argv[2], NULL, 0);
++        else if (!strncmp(argv[1], "bus", 3))
++                bus_override = simple_strtoul(argv[2], NULL, 0);
++	else
++		return CMD_RET_USAGE;
++
++	return 0;
++}
++
++U_BOOT_CMD(bflb_sdh, 3, 0, do_bflb_sdhci,
++        "tweak BL808 SDH clock generation",
++        "sdh divider - override SDH clock divider (0 to disable override)\n"
++        "bflb_sdh bus divider - override SD bus divider");
++
+ static const struct udevice_id bflb_sdhci_match[] = {
+ 	{ .compatible = "bflb,bl808-sdhci" },
+ 	{ }

--- a/board/pine64/ox64/rootfs-overlay/boot/extlinux/extlinux.conf
+++ b/board/pine64/ox64/rootfs-overlay/boot/extlinux/extlinux.conf
@@ -5,8 +5,8 @@ DEFAULT Pine64 OX64 Kernel
 LABEL Pine64 0X64 Kernel
 	KERNEL ../Image
 	FDT ../bl808-pine64-ox64.dtb
-	APPEND root=PARTLABEL=rootfs rootwait rw rootfstype=ext4 console=ttyS0,2000000 loglevel=8 earlycon=sbi
+	APPEND root=PARTLABEL=rootfs rootwait rw rootfstype=ext4 console=ttyS0,2000000 loglevel=8 earlycon=sbi ${bootargs}
 LABEL Sipeed M1SDock Kernel
 	KERNEL ../Image
 	FDT ../bl808-sipeed-m1s.dtb
-	APPEND root=PARTLABEL=rootfs rootwait rw rootfstype=ext4 console=ttyS0,2000000 loglevel=8 earlycon=sbi
+	APPEND root=PARTLABEL=rootfs rootwait rw rootfstype=ext4 console=ttyS0,2000000 loglevel=8 earlycon=sbi ${bootargs}

--- a/board/pine64/ox64/uboot_defconfig
+++ b/board/pine64/ox64/uboot_defconfig
@@ -19,7 +19,7 @@ CONFIG_BOOTSTD_DEFAULTS=y
 CONFIG_BOOTMETH_SCRIPT=y
 CONFIG_DYNAMIC_SYS_CLK_FREQ=y
 CONFIG_BOOTDELAY=5
-CONFIG_BOOTCOMMAND="mmc rescan; sleep 1; mmc rescan; run distro_bootcmd"
+CONFIG_BOOTCOMMAND="if mmc rescan; then else bflb_sdh sdh 8; bflb_sdh bus 1; setenv bootargs ${bootargs} sdhci-bflb.bus_div=1; fi; sleep 1; mmc rescan; run distro_bootcmd"
 # CONFIG_BOOTM_NETBSD is not set
 # CONFIG_BOOTM_PLAN9 is not set
 # CONFIG_BOOTM_RTEMS is not set


### PR DESCRIPTION
Note: this PR is not intended as a direct submission for upstreaming, but for review and evaluation.
This adds:
- U-Boot commands "bflb_sdh sdh" and "bflb_sdh bus"  to override clock dividers
- sdhci-bflr module parameter "sdhci-bflb.bus_div" to override the SD bus clock divider also in the kernel
- passing of boot command line arguments in U-Boot with the variable bootargs
- change the boot process to try, if mmc probe fails, with the following overrides:
  bflb_sdh sdh 8; bflb_sdh bus 1; setenv bootargs ${bootargs} sdhci-bflb.bus_div=1