### PR TITLE
package/blwnet_xram: update

### DIFF
--- a/package/blwnet_xram/blwnet_xram.mk
+++ b/package/blwnet_xram/blwnet_xram.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-BLWNET_XRAM_VERSION = d133be8588f46e7b48d8a43ba157fc8d40797288
+BLWNET_XRAM_VERSION = 2c00744670af7af3281e62677fafface3536617a
 BLWNET_XRAM_SITE = $(call github,bouffalolab,blwnet_xram,$(BLWNET_XRAM_VERSION))
 BLWNET_XRAM_LICENSE = GPL-2.0(kernel driver), Apache 2.0(userspace)
 


### PR DESCRIPTION
This PR mainly fixes Wi-Fi connection failure to WPA3 routers.
I remembered seeing community members in Discord group encounter the problem.

Also, MAC address in efuse will be used(rather than the default one, 18:B9:05:88:88:88).